### PR TITLE
README.md: Correct alt text for the 7-Zip logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 7-Zip with an enhanced SFX component
 
-![alt text](http://www.7-zip.org/7ziplogo.png)
+![7-Zip](http://www.7-zip.org/7ziplogo.png)
 
 For more than a decade now, Git for Windows made use of the "modified SFX" that used to be available from http://7zsfx.info. Sadly, that project seems to have gone defunct some time during 2016 and nobody seems to know why.
 


### PR DESCRIPTION
Hi,

This is a pretty small Pull Request. I noticed the README.md has an image which has alt text, but the text is literally just the words "alt text." (The image with this alt text is the 7-Zip logo, and it links to 7-Zip.org, for the record.)

_(Edit: Whoops, I just noticed It's not a link to 7-Zip.org, it's just a hyperlink to the URL of the image itself. Hmm.)_

I changed the alt text to say "7-Zip" instead. I'm not an expert, and I'm not a regular screen reader user myself, but I think that's right, based on this write-up/guide here: https://webaim.org/techniques/alttext/#logos

(Paraphrasing from that page: The alt text is considered correct and helpful if it could replace the image entirely, without that causing any problems. It's helpful for screen reader software that can speak the page aloud.)

So in looking out for blind users and other screen reader users, I felt this alt text could be improved.

Thanks for considering this PR.

Regards,

\- DeeDeeG

P.S.: To sum up what difference this makes, it's the difference between a screen reader saying aloud the phrase: "_alt text_, image, link" when focusing on that image, or saying: "_7-Zip_, image, link". (The latter being much more informative, of course.)