### PR TITLE
SFXSetup: enable Control Flow Guard

### DIFF
--- a/CPP/7zip/Bundles/SFXSetup/SFXSetup.vcxproj
+++ b/CPP/7zip/Bundles/SFXSetup/SFXSetup.vcxproj
@@ -97,6 +97,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DebugInformationFormat>None</DebugInformationFormat>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Midl>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -184,6 +185,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DebugInformationFormat>None</DebugInformationFormat>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Midl>
       <SuppressStartupBanner>true</SuppressStartupBanner>


### PR DESCRIPTION
The CI workflow builds two SFX flavors (`7zS.sfx` and `7zSD.sfx`) from `CPP/7zip/Bundles/SFXSetup/SFXSetup.sln`, but BinSkim flags both binaries for missing Control Flow Guard. Enable `/guard:cf` for the `Release` and `ReleaseD` configurations of `SFXSetup.vcxproj` so MSBuild propagates the flag to both `cl.exe` and `link.exe` (see https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard).

Verified locally with VS2022 (v143, MSVC 14.44.35207): the `cl.exe` and `link.exe` command lines now contain `/guard:cf`, and `dumpbin /headers /loadconfig` confirms the resulting binaries advertise the `Control Flow Guard` DLL characteristic, the `CF instrumented` guard flag, and a populated Guard CF function table (424 entries in `7zS.sfx`, 387 in `7zSD.sfx`). The `Debug` configuration is intentionally left alone since it is never produced by CI nor shipped.

Targeted at `Convert SFXSetup to VS2022` as a `fixup!` so it can be autosquashed into the original conversion to the modern toolset, where CFG support became available.