### PR TITLE
NtfsHandler: backport 7-Zip 26.01 ClusterSizeLog bound (CVE-2026-48095)

### DIFF
--- a/CPP/7zip/Archive/NtfsHandler.cpp
+++ b/CPP/7zip/Archive/NtfsHandler.cpp
@@ -130,7 +130,7 @@ bool CHeader::Parse(const Byte *p)
       else
         sectorsPerClusterLog = 0x100 - v;
       ClusterSizeLog = SectorSizeLog + sectorsPerClusterLog;
-      if (ClusterSizeLog > 30)
+      if (ClusterSizeLog > 21)
         return false;
     }
   }


### PR DESCRIPTION
Backports the one-line bounds tightening landed in upstream 7-Zip 26.01 (released 2026-04-27) for [CVE-2026-48095](https://nvd.nist.gov/vuln/detail/CVE-2026-48095).

## What changed upstream

7-Zip 26.01 changed `CPP/7zip/Archive/NtfsHandler.cpp:133` from:

```c
      if (ClusterSizeLog > 30)
        return false;
```

to:

```c
      if (ClusterSizeLog > 21)
        return false;
```

`GetCuSize()` further down in the same file computes:

```c
  UInt32 GetCuSize() const { return (UInt32)1 << (BlockSizeLog + CompressionUnit); }
```

With the old cap of 30, an NTFS image specifying `ClusterSizeLog = 28..30` plus `CompressionUnit = 4` makes the shift exponent reach 32, which is undefined behaviour for a 32-bit shift in C/C++. On x86/x64 the count is masked to the low 5 bits, so `GetCuSize()` returns `1` and `_inBuf` is allocated as 1 byte before the subsequent `ReadStream_FALSE` writes up to 256 MiB into it.

## Scope for this fork

This fork is on the `v26.00-VS2022-sfx` branch and focuses on SFX enhancements. The SFX deliverables typically exclude the NTFS handler, so the bug may not be reachable in shipped binaries here. Pulling in the upstream one-liner keeps `CPP/7zip/Archive/NtfsHandler.cpp` aligned with mainline 7-Zip and avoids surprises if a full build is ever produced from this tree.

## Patch

Single line, byte-for-byte the same as upstream 26.01:

```diff
-      if (ClusterSizeLog > 30)
+      if (ClusterSizeLog > 21)
```
