### PR TITLE
UefiHandler: fix off-by-one OOB read in ParseDepedencyExpression (backport 7-Zip 26.01)

### DIFF
--- a/CPP/7zip/Archive/UefiHandler.cpp
+++ b/CPP/7zip/Archive/UefiHandler.cpp
@@ -396,8 +396,8 @@ static bool ParseDepedencyExpression(const Byte *p, UInt32 size, AString &res)
   res.Empty();
   for (UInt32 i = 0; i < size;)
   {
-    unsigned command = p[i++];
-    if (command > Z7_ARRAY_SIZE(kExpressionCommands))
+    const unsigned command = p[i++];
+    if (command >= Z7_ARRAY_SIZE(kExpressionCommands))
       return false;
     res += kExpressionCommands[command];
     if (command < 3)


### PR DESCRIPTION
## Summary

`UefiHandler.cpp::ParseDepedencyExpression` has a one-off bounds check that allows reading one element past the end of the `kExpressionCommands` static const array when parsing a UEFI capsule's dependency expression section.

```cpp
static const char * const kExpressionCommands[] =
{
  "BEFORE", "AFTER", "PUSH", "AND", "OR", "NOT", "TRUE", "FALSE", "END", "SOR"
};

static bool ParseDepedencyExpression(const Byte *p, UInt32 size, AString &res)
{
  res.Empty();
  for (UInt32 i = 0; i < size;)
  {
    unsigned command = p[i++];
    if (command > Z7_ARRAY_SIZE(kExpressionCommands))   // <-- should be >=
      return false;
    res += kExpressionCommands[command];
    ...
```

`kExpressionCommands` has 10 entries (indices 0..9). The check `command > 10` only rejects `command >= 11`, so `command == 10` passes through and `kExpressionCommands[10]` is dereferenced, reading one pointer past the end of the static array into adjacent `.rodata`. The loaded value is then handed to `AString::operator+=(const char *)`, which calls `strlen` on whatever the bytes happen to look like as a pointer.

On most builds the adjacent memory holds another const string literal, so the result is just garbled output. On builds where the adjacent value is not a valid pointer (or points to unmapped memory), `strlen` SEGVs the unpacker when listing or extracting a malicious UEFI capsule that embeds a dependency-expression section whose first byte is `0x0A`.

## Fix

Tighten the comparison from `>` to `>=`, matching the upstream Igor Pavlov fix that shipped in the 7-Zip 26.01 source release. One-character semantic change, no functional difference for valid inputs (the kept-command set 0..9 is unchanged).

## Reproducer (informal)

Construct any UEFI capsule that the 7z handler recognizes (e.g. an EFI Firmware Volume containing a FFS file with a Section Type 0x13 "Dependency Expression" section) and place a single byte `0x0A` at the start of the dependency-expression payload. Listing the archive (`7z l capsule.cap`) will then load `kExpressionCommands[10]` and append a garbage pointer to the property string. Under AddressSanitizer this trips a `READ-of-size-N` past the end of the const array; without ASan the behaviour ranges from corrupted output to a crash depending on the linker's `.rodata` layout.

## References

- Upstream 26.01 source release applies the exact same change to `CPP/7zip/Archive/UefiHandler.cpp` line 400.
- This fork currently tracks the 26.00 source for `UefiHandler.cpp`; this commit aligns the predicate with 26.01.

Signed-off-by: tonghuaroot <tonghuaroot@gmail.com>