### PR TITLE
WimHandler: backport 7-Zip 26.01 securId+1 bounds check

### DIFF
--- a/CPP/7zip/Archive/Wim/WimHandler.cpp
+++ b/CPP/7zip/Archive/Wim/WimHandler.cpp
@@ -653,13 +653,13 @@ HRESULT CHandler::GetSecurity(UInt32 realIndex, const void **data, UInt32 *dataS
     return S_OK;
   const CImage &image = _db.Images[item.ImageIndex];
   const Byte *metadata = image.Meta + item.Offset;
-  UInt32 securityId = Get32(metadata + 0xC);
-  if (securityId == (UInt32)(Int32)-1)
+  const UInt32 securId = Get32(metadata + 0xC);
+  if (// securId == (UInt32)(Int32)-1 ||
+         securId     >= image.SecurOffsets.Size()
+      || securId + 1 >= image.SecurOffsets.Size())
     return S_OK;
-  if (securityId >= (UInt32)image.SecurOffsets.Size())
-    return E_FAIL;
-  UInt32 offs = image.SecurOffsets[securityId];
-  UInt32 len = image.SecurOffsets[securityId + 1] - offs;
+  const UInt32 offs = image.SecurOffsets[securId];
+  const UInt32 len = image.SecurOffsets[securId + 1] - offs;
   const CByteBuffer &buf = image.Meta;
   if (offs <= buf.Size() && buf.Size() - offs >= len)
   {


### PR DESCRIPTION
Backports the \`CHandler::GetSecurity()\` bounds-check tightening landed in upstream 7-Zip 26.01 (released 2026-04-27).

## What changed upstream

26.00 bounded \`securityId\` against \`image.SecurOffsets.Size()\` but the very next two lines do:

\`\`\`cpp
UInt32 offs = image.SecurOffsets[securityId];
UInt32 len = image.SecurOffsets[securityId + 1] - offs;
\`\`\`

So the second indexing reads one element past the end of the \`SecurOffsets\` array whenever \`securityId == SecurOffsets.Size() - 1\` (the last valid index).

26.01 changes the check to require both \`securId\` and \`securId + 1\` to be below \`SecurOffsets.Size()\`.

## Impact in 26.00

A crafted WIM image with a valid-looking-but-last security id produces a 4-byte out-of-bounds read of attacker-influenced metadata during \`GetProperty(kpidNtSecure)\`.

## Disclosure

I am not a native English speaker. AI tooling was used to polish the prose in this PR description. The fix itself is a direct backport from upstream 7-Zip 26.01 source.