### PR TITLE
SfxSetup: fix 1-byte OOB read in ReadDataString end-marker scan

### DIFF
--- a/CPP/7zip/Bundles/SFXSetup/SfxSetup.cpp
+++ b/CPP/7zip/Bundles/SFXSetup/SfxSetup.cpp
@@ -73,7 +73,7 @@ static bool ReadDataString(CFSTR fileName, LPCSTR startID,
     {
       if (writeMode)
       {
-        if (pos + signatureEndSize > numBytesPrev)
+        if (pos + signatureEndSize >= numBytesPrev)
           break;
         const Byte b = buffer[pos++];
         if (b == 0)
@@ -84,7 +84,7 @@ static bool ReadDataString(CFSTR fileName, LPCSTR startID,
       }
       else
       {
-        if (pos + signatureStartSize > numBytesPrev)
+        if (pos + signatureStartSize >= numBytesPrev)
           break;
         const Byte b = buffer[pos++];
         if (b == ';' && memcmp(buffer + pos, startID + 1, signatureStartSize) == 0)


### PR DESCRIPTION
Backports the off-by-one fix landed in upstream 7-Zip 26.01 (released 2026-04-27) for the SFX self-extracting installer's config-block parser.

## What changed upstream

The relevant control flow in 26.00 \`ReadDataString()\` is:

\`\`\`cpp
if (pos + signatureEndSize > numBytesPrev)   // pos here = pos_orig
  break;
const Byte b = buffer[pos++];                // pos becomes pos_orig + 1
if (b == ';' && memcmp(buffer + pos, endID + 1, signatureEndSize) == 0)
  return true;
\`\`\`

The \`memcmp\` reads \`buffer[pos_orig+1 .. pos_orig+signatureEndSize]\`, i.e. the final byte read is at index \`pos_orig + signatureEndSize\`. A correct guard requires \`pos_orig + signatureEndSize < numBytesPrev\`. The 26.00 check uses \`>\` which lets \`pos_orig + signatureEndSize == numBytesPrev\` (kBufferSize = 4096) slip through, so \`memcmp\` reads \`buffer[numBytesPrev]\` -- 1 byte past the end of the stack buffer when the input layout is crafted to align the trailing window of the read.

26.01 changes the check to \`>=\`, which is what this PR backports. The same off-by-one exists in the start-marker scan; this PR fixes that branch too to keep the two scanners in lockstep with upstream.

## Patch

Two characters changed (\`>\` -> \`>=\` in each scanner branch), byte-for-byte identical to upstream 26.01 source.

## Disclosure

I am not a native English speaker. AI tooling was used to polish the prose in this PR description. The fix itself is a direct backport from upstream 7-Zip 26.01 source.