### PR TITLE
SFXSetup: enable Control Flow Guard

### DIFF
--- a/CPP/7zip/Bundles/SFXSetup/SFXSetup.vcxproj
+++ b/CPP/7zip/Bundles/SFXSetup/SFXSetup.vcxproj
@@ -97,6 +97,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DebugInformationFormat>None</DebugInformationFormat>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Midl>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -184,6 +185,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DebugInformationFormat>None</DebugInformationFormat>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Midl>
       <SuppressStartupBanner>true</SuppressStartupBanner>


### PR DESCRIPTION
The CI workflow builds two SFX flavors (`7zS.sfx` and `7zSD.sfx`) from `CPP/7zip/Bundles/SFXSetup/SFXSetup.sln`, but BinSkim flags both binaries for missing Control Flow Guard. Enable `/guard:cf` for the `Release` and `ReleaseD` configurations of `SFXSetup.vcxproj` so MSBuild propagates the flag to both `cl.exe` and `link.exe` (see https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard).

This ports #32 to v26.01.